### PR TITLE
Allow user to generate with snake cased classname

### DIFF
--- a/lib/generators/searcher/searcher_generator.rb
+++ b/lib/generators/searcher/searcher_generator.rb
@@ -16,6 +16,7 @@ class SearcherGenerator < Rails::Generators::NamedBase
   private
   def model_names
     ARGV
+      .map(&:classify)
       .select{|model_name| is_app_class?(model_name)}
       .map(&:underscore)
   end


### PR DESCRIPTION
Ensures that before haystack tries to generate a searcher, it maps the
entered class name through a transform so that it is TitleCased as rails
expects classes to be.

This allows them to write either
  rails g searcher ClassName

OR

  rails g searcher class_name

Fixes #13
