### PR TITLE
Better Handle Multiple Models at Command Line

### DIFF
--- a/lib/generators/searcher/searcher_generator.rb
+++ b/lib/generators/searcher/searcher_generator.rb
@@ -1,7 +1,8 @@
 # Generates searchers with concrete functionality, when passed model names
 # i.e. rails g searcher User will create a UserSearcher
-class SearcherGenerator < Rails::Generators::NamedBase
+class SearcherGenerator < Rails::Generators::Base
   source_root File.expand_path('../templates', __FILE__)
+  argument :models, type: :array, required: true
   class_option :views, type: :boolean, default: true, desc: "Generate views"
 
   def create_searcher_model
@@ -9,7 +10,9 @@ class SearcherGenerator < Rails::Generators::NamedBase
     # unless Dir.exists? guards against deleting entire directory on `rails destroy`
     empty_directory dir_name unless Dir.exists?(dir_name)
     model_names.each do |name|
-      template "searcher_template.rb", File.join("app","searchers", "#{name}_searcher.rb")
+      # must use ivar to share state with Template file ERB
+      @model = name
+      template "searcher_template.rb", File.join("app","searchers", "#{@model}_searcher.rb")
     end
   end
 
@@ -25,7 +28,7 @@ class SearcherGenerator < Rails::Generators::NamedBase
 
   private
   def model_names
-    ARGV
+    models
       .select{|model_name| is_app_class?(model_name)}
       .map(&:underscore)
   end

--- a/lib/generators/searcher/templates/searcher_template.rb
+++ b/lib/generators/searcher/templates/searcher_template.rb
@@ -1,10 +1,11 @@
 ###############################################################################
-# <%= name.camelize %>Searcher: Searches over your <%= name.camelize %> Model
+# <%= @model.camelize %>Searcher: Searches over your <%= @model.camelize %> Model
 # 
 ###############################################################################
-class <%= name.camelize %>Searcher < Haystack::BaseSearcher
 
-  BASE = <%= name.camelize %>
+class <%= @model.camelize %>Searcher < Haystack::BaseSearcher
+
+  BASE = <%= @model.camelize %>
 
   #############################################################################
   # SEARCHABLE FIELDS: uncomment `attr_accessor` below and define any model


### PR DESCRIPTION
Previously, we were using ARGV to capture model names from the command
line. This worked until we started adding cli options, which got
vacuumed up with the other parts.

This commit changes to using the Thor .argument method to capture the
model names by position (as an array). We also move off of NamedBase and
onto Generator::Base, which is more semantically correct.

Fixes#16
