### PR TITLE
Allow snake-cased entry at Command Line

### DIFF
--- a/lib/generators/searcher/searcher_generator.rb
+++ b/lib/generators/searcher/searcher_generator.rb
@@ -29,6 +29,7 @@ class SearcherGenerator < Rails::Generators::Base
   private
   def model_names
     models
+      .map(&:classify)
       .select{|model_name| is_app_class?(model_name)}
       .map(&:underscore)
   end


### PR DESCRIPTION
Ensures that before haystack tries to generate a searcher, it maps the
entered class name through a transform so that it is TitleCased as rails
expects classes to be.

This allows them to write either
rails g searcher ClassName

OR

rails g searcher class_name
